### PR TITLE
Fix support for JupyterHub 3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,14 +32,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.5"
-          - "3.9"
+          - "3.6"
+          - "3.10"
         JHUB_VER:
-          - "0.9.6"
           - "1.0.0"
-          - "1.1.0"
-          - "1.2.0"
-          - "1.3.0"
+          - "1.5.1"
+          - "2.3.1"
         allow_failure: [false]
 
         exclude:
@@ -51,6 +49,9 @@ jobs:
             python-version: "3.9"
         include:
           - JHUB_VER: "main"
+            python-version: "3.9"
+            allow_failure: true
+          - JHUB_VER: "3.0.0"
             python-version: "3.9"
             allow_failure: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,13 @@ repos:
     rev: "22.12.0"
     hooks:
       - id: black
-        args: [--target-version=py36]
+        args:
+          - --target-version=py36
+          - --target-version=py37
+          - --target-version=py38
+          - --target-version=py39
+          - --target-version=py310
+          - --target-version=py311
 
   # Autoformat: markdown, yaml
   - repo: https://github.com/pre-commit/mirrors-prettier
@@ -48,3 +54,8 @@ repos:
 
       # Lint: Checks that non-binary executables have a proper shebang.
       - id: check-executables-have-shebangs
+
+
+# pre-commit.ci config reference: https://pre-commit.ci/#configuration
+ci:
+  autoupdate_schedule: monthly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,26 +11,26 @@
 repos:
   # Autoformat: Python code
   - repo: https://github.com/psf/black
-    rev: "22.8.0"
+    rev: "22.12.0"
     hooks:
       - id: black
         args: [--target-version=py36]
 
   # Autoformat: markdown, yaml
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.0
+    rev: v3.0.0-alpha.4
     hooks:
       - id: prettier
 
   # Lint: Python code
   - repo: https://github.com/PyCQA/flake8
-    rev: "5.0.4"
+    rev: "6.0.0"
     hooks:
       - id: flake8
 
   # Misc...
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     # ref: https://github.com/pre-commit/pre-commit-hooks#hooks-available
     hooks:
       # Autoformat: Makes sure files end in a newline and only a newline.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,6 @@ repos:
       # Lint: Checks that non-binary executables have a proper shebang.
       - id: check-executables-have-shebangs
 
-
 # pre-commit.ci config reference: https://pre-commit.ci/#configuration
 ci:
   autoupdate_schedule: monthly

--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import sys
 
@@ -7,6 +8,7 @@ from shutil import which
 from jupyterhub.utils import random_port, url_path_join
 from jupyterhub.services.auth import HubAuth
 
+from tornado.escape import json_encode
 
 def main(argv=None):
     port = random_port()
@@ -14,10 +16,12 @@ def main(argv=None):
     hub_auth.client_ca = os.environ.get("JUPYTERHUB_SSL_CLIENT_CA", "")
     hub_auth.certfile = os.environ.get("JUPYTERHUB_SSL_CERTFILE", "")
     hub_auth.keyfile = os.environ.get("JUPYTERHUB_SSL_KEYFILE", "")
-    hub_auth._api_request(
-        method="POST",
-        url=url_path_join(hub_auth.api_url, "batchspawner"),
-        json={"port": port},
+    asyncio.run(
+        hub_auth._api_request(
+            method="POST",
+            url=url_path_join(hub_auth.api_url, "batchspawner"),
+            body=json_encode({"port": port})
+        )
     )
 
     cmd_path = which(sys.argv[1])

--- a/batchspawner/singleuser.py
+++ b/batchspawner/singleuser.py
@@ -10,6 +10,7 @@ from jupyterhub.services.auth import HubAuth
 
 from tornado.escape import json_encode
 
+
 def main(argv=None):
     port = random_port()
     hub_auth = HubAuth()
@@ -20,7 +21,7 @@ def main(argv=None):
         hub_auth._api_request(
             method="POST",
             url=url_path_join(hub_auth.api_url, "batchspawner"),
-            body=json_encode({"port": port})
+            body=json_encode({"port": port}),
         )
     )
 

--- a/version.py
+++ b/version.py
@@ -4,7 +4,7 @@
 version_info = (
     1,
     2,
-    1,
+    2,
 #    "dev",  # comment-out this line for a release
 )
 __version__ = ".".join(map(str, version_info))

--- a/version.py
+++ b/version.py
@@ -5,6 +5,6 @@ version_info = (
     1,
     2,
     0,
-#    "dev",  # comment-out this line for a release
+    #    "dev",  # comment-out this line for a release
 )
 __version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
Sync with upstream master to get https://github.com/jupyterhub/batchspawner/pull/247. This fixes support for JupyterHub 3.

This fix is already merged upstream, but there are no new releases yet.